### PR TITLE
Remove port exposure for frontend, backend and nginx

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,22 +23,16 @@ services:
             dockerfile: Dockerfile
         volumes:
             - ./db:/usr/src/app/db
-        ports:
-            - 3000:3000
     frontend:
         build:
             context: frontend
             dockerfile: Dockerfile
         depends_on:
             - backend
-        ports:
-            - 5000:5000
     nginx:
         build:
             context: nginx
             dockerfile: Dockerfile
-        ports:
-            - 8443:8443
         depends_on:
             - backend
             - frontend


### PR DESCRIPTION
Traefik is now the only entry point to the docker network